### PR TITLE
chore(deps): bump @wellenplan/directus-extension-duration-interface from 0.1.8 to 0.1.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@wellenplan/directus-extension-duration-display": "^0.1.11",
-        "@wellenplan/directus-extension-duration-interface": "^0.1.8",
+        "@wellenplan/directus-extension-duration-interface": "^0.1.9",
         "@wellenplan/directus-extension-hourclock-interface": "^0.1.12",
         "@wellenplan/directus-extension-hourclock-module": "^0.1.8",
         "@wellenplan/directus-extension-wellenplan-hook": "^0.1.7",
@@ -2311,9 +2311,9 @@
       "integrity": "sha512-47g90FtVYEwXcY5f/YjOQ07zgt2hwvTKy2XdHpafIhtteqQFd9OeQQxqZ78jbzkXv3GunImKGIQNoRMRBEPZsw=="
     },
     "node_modules/@wellenplan/directus-extension-duration-interface": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@wellenplan/directus-extension-duration-interface/-/directus-extension-duration-interface-0.1.8.tgz",
-      "integrity": "sha512-C+WS7+ro92r9XPpiF/Zpl/kv23xa3xu4CCWRiWV2LVw73bjiH3UPoXW0p6MQUhZf5UbnSocAWaZr3hSaEyuIlQ=="
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@wellenplan/directus-extension-duration-interface/-/directus-extension-duration-interface-0.1.9.tgz",
+      "integrity": "sha512-w2O8INYVsMACAQNIpUbjMIGPi3+fwyOEPGA7hmF+T3jywLQ3SArlGnyh6qrnCD2Br2KIbeJBDMpUjugwTf89hQ=="
     },
     "node_modules/@wellenplan/directus-extension-hourclock-interface": {
       "version": "0.1.12",
@@ -12832,9 +12832,9 @@
       "integrity": "sha512-47g90FtVYEwXcY5f/YjOQ07zgt2hwvTKy2XdHpafIhtteqQFd9OeQQxqZ78jbzkXv3GunImKGIQNoRMRBEPZsw=="
     },
     "@wellenplan/directus-extension-duration-interface": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@wellenplan/directus-extension-duration-interface/-/directus-extension-duration-interface-0.1.8.tgz",
-      "integrity": "sha512-C+WS7+ro92r9XPpiF/Zpl/kv23xa3xu4CCWRiWV2LVw73bjiH3UPoXW0p6MQUhZf5UbnSocAWaZr3hSaEyuIlQ=="
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@wellenplan/directus-extension-duration-interface/-/directus-extension-duration-interface-0.1.9.tgz",
+      "integrity": "sha512-w2O8INYVsMACAQNIpUbjMIGPi3+fwyOEPGA7hmF+T3jywLQ3SArlGnyh6qrnCD2Br2KIbeJBDMpUjugwTf89hQ=="
     },
     "@wellenplan/directus-extension-hourclock-interface": {
       "version": "0.1.12",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "dependencies": {
     "@wellenplan/directus-extension-duration-display": "^0.1.11",
-    "@wellenplan/directus-extension-duration-interface": "^0.1.8",
+    "@wellenplan/directus-extension-duration-interface": "^0.1.9",
     "@wellenplan/directus-extension-hourclock-interface": "^0.1.12",
     "@wellenplan/directus-extension-hourclock-module": "^0.1.8",
     "@wellenplan/directus-extension-wellenplan-hook": "^0.1.7",


### PR DESCRIPTION
replaces #47 